### PR TITLE
add MdxEmbedProvider to blog-post-template

### DIFF
--- a/posts/2020/01/28/update-wsl-ubuntu-from-18.10-to-19.10/index.mdx
+++ b/posts/2020/01/28/update-wsl-ubuntu-from-18.10-to-19.10/index.mdx
@@ -7,8 +7,6 @@ cover: ./cover.jpg
 coverCredit: Photo by Daniel Kuruvilla on Unsplash
 ---
 
-import { YouTube } from '@pauliescanlon/gatsby-mdx-embed';
-
 In this guide I'm going to detail upgrading a Windows Subsystem Linux
 (WSL) Ubuntu install from the current version 18.04 to 19.10 this is
 an intermediary release before Ubuntu 20.04 is released on 2020

--- a/src/templates/blog-post-template.js
+++ b/src/templates/blog-post-template.js
@@ -6,6 +6,7 @@ import { Layout } from '../components/layout';
 import { H1 } from '../components/page-elements';
 import { StyledDate } from '../components/shared';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { MdxEmbedProvider } from '@pauliescanlon/gatsby-mdx-embed';
 
 export default ({ data, pageContext }) => {
   const {
@@ -42,7 +43,9 @@ export default ({ data, pageContext }) => {
       />
       <H1>{frontmatter.title}</H1>
       <StyledDate>{frontmatter.date}</StyledDate>
-      <MDXRenderer>{body}</MDXRenderer>
+      <MdxEmbedProvider>
+        <MDXRenderer>{body}</MDXRenderer>
+      </MdxEmbedProvider>
       {previous === false ? null : (
         <>
           {previous && (


### PR DESCRIPTION
Hey dude! 

I had a look into that pesky full screen YouTube problem and i think it comes down to a clash of MdxProviders. 

By commenting out the plugins in `gatsby-config.js` one by one i was able to determine that `gatsby-plugin-feed` seems to be a problem. 

It's difficult to say why but in either case i found the following fixed the problem.

in `blog-post-template.js` i've imported the `MdxEmbedProvider` and used it to wrap your `<MDXRenderer />`... in theory this is doing what the plugin does anyway but `MdxProviders` can be a bit tricky and as Chris Biscardi says 

> "Multiple providers will merge the components object. Last provider wins"

To that end you _could_ now remove` gatsby-mdx-embed` from your `gatsby-config.js` but perhaps it makes more sense to leave it in so you can see at a glance which plugins your site uses.

What i'm not so sure about is if this fix breaks anything `gatsby-plugin-feed` was doing?
It does however solve the full screen YouTube problem.

I think this approach of manually adding the provider is better than importing components in to each`.mdx` file... and should there be a fix later on down the line with either `gatsby-mdx-embed` or `gatsby-plugin-feed` you'll only need to amend `blog-post-template.js` rather than going back over all of your `.mdx` files and removing the imports.

Lemme know how you get on! 

✌️

